### PR TITLE
use ~/.cache/vim for swapfiles

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -119,6 +119,11 @@ set ffs=unix,dos,mac         " use unix as standard file format
 "
 set nobackup                 " no *~ backup files
 
+if isdirectory('~/.cache/vim') == 0
+	:silent !install -dm700 ~/.cache/vim >/dev/null 2>&1
+endif
+set directory=~/.cache/vim
+
 
 "
 " Statusline


### PR DESCRIPTION
This removes the nasty `.$FILE.swp` files. It'll move them to a cache-directory inside home.

Some users use this with /tmp/vim-$user/ as value. But then after an unexpected reboot/shutdown your changes are gone.